### PR TITLE
feature-erms-817

### DIFF
--- a/app/application.properties
+++ b/app/application.properties
@@ -1,7 +1,7 @@
 #Grails Metadata file
-#Mon Jan 07 08:07:57 CET 2019
-app.buildDate=07.01.2019 08\:07
-app.buildNumber=6551
+#Mon Jan 07 14:00:59 CET 2019
+app.buildDate=07.01.2019 14\:00
+app.buildNumber=6557
 app.buildProfile=development
 app.grails.version=2.5.6
 app.name=laser

--- a/app/grails-app/i18n/messages.properties
+++ b/app/grails-app/i18n/messages.properties
@@ -2265,8 +2265,9 @@ gasco.filter.allianceLicence = Allianzlizenz
 gasco.filter.consotialLicence = Konsortiallizenz
 gasco.filter.consotialAuthority = Konsortialstelle
 
-gasco.table.product = Produkt
-gasco.table.Ppovider = Anbieter
-gasco.table.consortium = Konsortium / Negotiator
+gasco.table.product=Product
+gasco.table.provider=Provider
+gasco.table.consortium=Consortium / Negotiator
+gasco.table.negotiator=Negotiator
 
 attribute = Attribute

--- a/app/grails-app/i18n/messages.properties
+++ b/app/grails-app/i18n/messages.properties
@@ -2257,13 +2257,13 @@ message.information = Information
 message.attantion.needTime = In case not finding a new element please wait  about <strong>10 minutes</strong> untill the index is updated.
 
 #----GASCO----
-gasco.title = GASCO products
-gasco.filter.licenceOrProviderSearch = Lizenz- oder Anbietersuche
-gasco.filter.licenceType = Lizenztyp
-gasco.filter.nationalLicence = Nationallizenz
-gasco.filter.allianceLicence = Allianzlizenz
-gasco.filter.consotialLicence = Konsortiallizenz
-gasco.filter.consotialAuthority = Konsortialstelle
+gasco.title=GASCO products
+gasco.filter.licenceOrProviderSearch=Lizenz- oder Anbietersuche
+gasco.filter.licenceType=Lizenztyp
+gasco.filter.nationalLicence=Nationallizenz
+gasco.filter.allianceLicence=Allianzlizenz
+gasco.filter.consotialLicence=Konsortiallizenz
+gasco.filter.consotialAuthority=Konsortialstelle
 
 gasco.table.product=Product
 gasco.table.provider=Provider

--- a/app/grails-app/i18n/messages_de.properties
+++ b/app/grails-app/i18n/messages_de.properties
@@ -2413,9 +2413,10 @@ gasco.filter.consotialLicence = Konsortiallizenz
 gasco.filter.consotialAuthority = Konsortialstelle
 gasco.filter.chooseConsotialAuthority = Konsortialstelle auswählen
 
-gasco.table.product = Produkt
-gasco.table.Ppovider = Anbieter
-gasco.table.consortium = Konsortium / Verhandlungsführer
+gasco.table.product=Produkt
+gasco.table.provider=Anbieter
+gasco.table.consortium=Konsortium / Verhandlungsführer
+gasco.table.negotiator=Verhandlungsführer
 
 platforms.all_platforms.label = Alle Plattformen
 

--- a/app/grails-app/views/public/gasco.gsp
+++ b/app/grails-app/views/public/gasco.gsp
@@ -26,9 +26,7 @@
                                    value="${params.q}"/>
                         </div>
                     </div>
-                    %{--Task ERMS-587: Vorübergehende Auswahl der Konsortiallizenz und Ausblenden der Auswahlckeckboxen --}%
-                    %{--TODO: Display none wieder entfernen--}%
-                    <div class="field" style="display: none">
+                    <div class="field">
                         <label for="subscritionType">${message(code: 'myinst.currentSubscriptions.subscription_type')}</label>
                         <fieldset id="subscritionType">
                             <div class="inline fields la-filter-inline">
@@ -36,8 +34,14 @@
                                 <g:each in="${RefdataCategory.getAllRefdataValues('Subscription Type')}" var="subType">
                                     <g:if test="${subType.value != 'Local Licence'}">
                                         <g:if test="${subType.value == 'National Licence'}">
-                                            <div class="inline field js-consortiallicence">
+                                            <div class="inline field js-nationallicence">
                                         </g:if>
+                                        <g:elseif test="${subType.value == 'Alliance Licence'}">
+                                            <div class="inline field js-alliancelicence">
+                                        </g:elseif>
+                                        <g:elseif test="${subType.value == 'Consortial Licence'}">
+                                            <div class="inline field js-consortiallicence">
+                                        </g:elseif>
                                         <g:else>
                                             <div class="inline field">
                                         </g:else>
@@ -45,13 +49,8 @@
                                             <div class="ui checkbox">
                                                 <label for="checkSubType-${subType.id}">${subType.getI10n('value')}</label>
                                                 <input id="checkSubType-${subType.id}" name="subTypes" type="checkbox" value="${subType.id}"
-                                                %{--TODO: Wieder einkommentieren: Original-Code Beginn--}%
-                                                    %{--<g:if test="${params.list('subTypes').contains(subType.id.toString())}"> checked="" </g:if>--}%
-                                                    %{--<g:if test="${initQuery}"> checked="" </g:if>--}%
-                                                %{--TODO Original-Code Ende--}%
-                                                %{--TODO Diese Vorauswahl muss wieder entfernt werden--}%
-                                                    <g:if test="${subType.value == 'Consortial Licence'}"> checked="" </g:if>
-                                                %{--TODO Vorauswahl-Ende--}%
+                                                    <g:if test="${params.list('subTypes').contains(subType.id.toString())}"> checked="" </g:if>
+                                                    <g:if test="${initQuery}"> checked="" </g:if>
                                                        tabindex="0">
 
                                             </div>
@@ -85,24 +84,31 @@
             <img class="ui fluid image" alt="Logo GASCO" class="ui fluid image" src="images/gasco/GASCO-Logo-2_klein.jpg"/>
         </div>
     </div>
-    <%--
     <r:script>
         $(document).ready(function() {
 
             function toggleFilterPart() {
                 if ($('.js-consortiallicence input').prop('checked')) {
-                    $('#js-consotial-authority .dropdown').addClass('disabled')
-                    $('#js-consotial-authority select').attr('disabled', 'disabled')
-                } else {
                     $('#js-consotial-authority .dropdown').removeClass('disabled')
                     $('#js-consotial-authority select').removeAttr('disabled')
+                } else {
+                    $('#js-consotial-authority .dropdown').addClass('disabled')
+                    $('#js-consotial-authority select').attr('disabled', 'disabled')
+                }
+                if ($('.js-nationallicence input').prop('checked') || $('.js-alliancelicence input').prop('checked')) {
+                    $('#js-negotiator-header').show()
+                    $('#js-consortium-header').hide()
+                } else {
+                    $('#js-negotiator-header').hide()
+                    $('#js-consortium-header').show()
                 }
             }
             toggleFilterPart()
+            $('.js-nationallicence').on('click', toggleFilterPart)
+            $('.js-alliancelicence').on('click', toggleFilterPart)
             $('.js-consortiallicence').on('click', toggleFilterPart)
         });
     </r:script>
-    --%>
     <g:if test="${subscriptions}">
 
     <table class="ui celled la-table table">
@@ -110,10 +116,15 @@
         <tr>
             <th>${message(code:'sidewide.number')}</th>
             <th>${message(code:'gasco.table.product')}</th>
-            <th>${message(code:'gasco.table.Ppovider')}</th>
+            <th>${message(code:'gasco.table.provider')}</th>
             %{--Task ERMS-587: Temporäres Ausblenden dieser Spalte--}%
             %{--<th>${message(code:'gasco.licenceType')}</th>--}%
-            <th>${message(code:'gasco.table.consortium')}</th>
+            <th>
+                <div id="js-consortium-header">
+                    ${message(code:'gasco.table.consortium')}</div>
+                <div id="js-negotiator-header">
+                    ${message(code:'gasco.table.negotiator')}</div>
+            </th>
         </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
feature-erms-817: GASCO Lizenztyp wieder einblenden und nutzbar machen