### PR TITLE
feature-erms-1094

### DIFF
--- a/app/grails-app/controllers/com/k_int/kbplus/SubscriptionDetailsController.groovy
+++ b/app/grails-app/controllers/com/k_int/kbplus/SubscriptionDetailsController.groovy
@@ -715,20 +715,20 @@ class SubscriptionDetailsController extends AbstractDebugController {
                         //make checks ...
                         //is title in LAS:eR?
                         //List tiObj = TitleInstancePackagePlatform.executeQuery('select tipp from TitleInstancePackagePlatform tipp join tipp.title ti join ti.ids identifiers where identifiers.identifier.value in :idCandidates',[idCandidates:idCandidates])
-                        log.debug(idCandidates)
+                        //log.debug(idCandidates)
                         def tiObj = TitleInstance.findByIdentifier(idCandidates)
                         if(tiObj) {
                             //is title already added?
                             List issueEntitlement = IssueEntitlement.executeQuery('select ie from IssueEntitlement ie where ie.tipp in :tipp and ie.subscription = :sub',[tipp:tiObj,sub:result.subscriptionInstance])
                             if(issueEntitlement) {
-                                errorList.add(g.message([code:'subscription.details.addEntitlements.titleAlreadyAdded',args:[cols[0]]]))
+                                errorList.add("${cols[0]}&#9;${cols[zdbCol] ?: " "}&#9;${cols[onlineIdentifierCol] ?: " "}&#9;${cols[printIdentifierCol] ?: " "}&#9;${message(code:'subscription.details.addEntitlements.titleAlreadyAdded')}")
                             }
                             /*else if(!issueEntitlement) {
                                 errors += g.message([code:'subscription.details.addEntitlements.titleNotMatched',args:cols[0]])
                             }*/
                         }
                         else if(!tiObj) {
-                            errorList.add(g.message([code:'subscription.details.addEntitlements.titleNotInERMS',args:[cols[0]]]))
+                            errorList.add("${cols[0]}&#9;${cols[zdbCol] ?: " "}&#9;${cols[onlineIdentifierCol] ?: " "}&#9;${cols[printIdentifierCol] ?: " "}&#9;${message(code:'subscription.details.addEntitlements.titleNotInERMS')}")
                         }
                     }
                 }
@@ -779,7 +779,7 @@ class SubscriptionDetailsController extends AbstractDebugController {
             result.tipps = []
         }
         if(errorList)
-            flash.error = errorList.join("<br>")
+            flash.error = "<pre style='font-family:Lato,Arial,Helvetica,sans-serif;'>"+errorList.join("\n")+"</pre>"
         result
     }
 

--- a/app/grails-app/i18n/messages.properties
+++ b/app/grails-app/i18n/messages.properties
@@ -1399,8 +1399,8 @@ subscription.details.addEntitlements.add_now = Add now
 subscription.details.addEntitlements.add_selected = Add Selected Entitlements
 subscription.details.addEntitlements.preselect = Preselect Entitlements per KBART-File
 subscription.details.addEntitlements.unidentified = The following titles of the KBart-file {0} could not be matched: {1}
-subscription.details.addEntitlements.titleNotInERMS = The title {0} is not in LAS:eR-database!
-subscription.details.addEntitlements.titleAlreadyAdded = The title {0} is already added to subscription issue entitlements!
+subscription.details.addEntitlements.titleNotInERMS = <strong>Not in LAS:eR-database</strong>
+subscription.details.addEntitlements.titleAlreadyAdded = <strong>Already added to subscription holding</strong>
 subscription.details.addEntitlements.titleNotMatched = The title {0} could not be matched!
 
 subscription.details.members.label = Members

--- a/app/grails-app/i18n/messages_de.properties
+++ b/app/grails-app/i18n/messages_de.properties
@@ -1374,8 +1374,8 @@ subscription.details.addEntitlements.add_now = Jetzt hinzufügen
 subscription.details.addEntitlements.add_selected = Ausgewählte Titel hinzufügen
 subscription.details.addEntitlements.preselect = Titel per KBART-Datei vorauswählen
 subscription.details.addEntitlements.unidentified = Die folgenden Titel aus der KBart-Datei {0} hatten keine Identifikatoren: {1}
-subscription.details.addEntitlements.titleNotInERMS = Der Titel {0} ist nicht in LAS:eR vorhanden!
-subscription.details.addEntitlements.titleAlreadyAdded = Der Titel {0} ist bereits zur Lizenz hinzugefügt!
+subscription.details.addEntitlements.titleNotInERMS = <strong>Nicht in LAS:eR vorhanden</strong>
+subscription.details.addEntitlements.titleAlreadyAdded = <strong>Bereits zum Lizenzbestand hinzugefügt</strong>
 subscription.details.addEntitlements.titleNotMatched = Der Titel {0} konnte im Paket nicht gefunden werden!
 
 subscription.details.members.label = Teilnehmer


### PR DESCRIPTION
for ERMS-1094: output of KBart issue entitlement activation errors in tab-separated list which may be copied into a tsv file