### PR TITLE
bug-erms-1954/1955

### DIFF
--- a/app/CHANGELOG-TMP.md
+++ b/app/CHANGELOG-TMP.md
@@ -2,6 +2,8 @@
 
 **Ticket    Date    Branch      Author  Feature/Bug     Description/Keywords**
  
+1954/1955   10.12.2019  rc1.1   Andreas Bug         NullPointerException bei Laden der Lizenz für Kostenposten behoben
+
 1953    10.12.2019  rc1.1       Andreas Bug         NullPointerException bei Prozessierung der Anbieternamen behoben
  
  /      06.12.2019  rc1.1       Andreas Bug         Entfernen der Währungsbezeichnung aus den Finanzsichten

--- a/app/grails-app/controllers/com/k_int/kbplus/FinanceController.groovy
+++ b/app/grails-app/controllers/com/k_int/kbplus/FinanceController.groovy
@@ -787,11 +787,11 @@ class FinanceController extends AbstractDebugController {
 
         if(!params.sub.isEmpty() && StringUtils.isNumeric(params.sub)){
             result.sub = Subscription.get(Long.parseLong(params.sub))
-            if(contextService.org.id == result.sub.getConsortia().id) {
+            if(contextService.org.id == result.sub.getConsortia()?.id) {
                 result.licenseeLabel = message(code: 'consortium.member')
                 result.licenseeTargetLabel = message(code:'consortium.member.plural')
             }
-            else if(contextService.org.id == result.sub.getCollective().id) {
+            else if(contextService.org.id == result.sub.getCollective()?.id) {
                 result.licenseeLabel = message(code:'collective.member')
                 result.licenseeTargetLabel = message(code:'collective.member.plural')
             }


### PR DESCRIPTION
as of ERMS-1954 and ERMS-1955, null pointer checks have been introduced when loading consortium or collective for given subscription