### PR TITLE
Do not show AccessPoints for every platform/package

### DIFF
--- a/app/grails-app/domain/com/k_int/kbplus/Subscription.groovy
+++ b/app/grails-app/domain/com/k_int/kbplus/Subscription.groovy
@@ -827,6 +827,21 @@ class Subscription
       return hasUsageSupplier
   }
 
+  def deduplicatedAccessPointsForOrgAndPlatform(org, platform) {
+      def hql = """
+select distinct oap from OrgAccessPoint oap 
+    join oap.oapp as oapl
+    join oapl.subPkg as subPkg
+    join subPkg.subscription as sub
+    where sub=:sub
+    and oap.org=:org
+    and oapl.active=true
+    and oapl.platform=:platform
+    
+"""
+      return OrgAccessPointLink.executeQuery(hql, [sub:this, org:org, platform:platform])
+  }
+
   def getHoldingTypes() {
       def types = issueEntitlements?.tipp?.title?.type?.unique()
       types

--- a/app/grails-app/domain/com/k_int/kbplus/Subscription.groovy
+++ b/app/grails-app/domain/com/k_int/kbplus/Subscription.groovy
@@ -839,7 +839,7 @@ select distinct oap from OrgAccessPoint oap
     and oapl.platform=:platform
     
 """
-      return OrgAccessPointLink.executeQuery(hql, [sub:this, org:org, platform:platform])
+      return OrgAccessPoint.executeQuery(hql, [sub:this, org:org, platform:platform])
   }
 
   def getHoldingTypes() {

--- a/app/grails-app/i18n/messages.properties
+++ b/app/grails-app/i18n/messages.properties
@@ -2440,7 +2440,7 @@ myinst.changeLog.restrictTo = Restrict to
 myinst.changelog.all = ALL
 
 myinst.currentPlatforms.assignedSubscriptions = Assigned active subscriptions
-myinst.currentPlatforms.tooltip.thumbtack.content = There will be a dedicated Accesspoint configuration for package [{0}]
+myinst.currentPlatforms.tooltip.thumbtack.content = There is a dedicated Access configuration
 
 myinst.dash.forum.label = Latest Discussions
 myinst.dash.forum.noActivity = Recent forum activity not available. Please retry later.

--- a/app/grails-app/i18n/messages_de.properties
+++ b/app/grails-app/i18n/messages_de.properties
@@ -2293,7 +2293,7 @@ myinst.changeLog.restrictTo = Beschränken auf
 myinst.changelog.all = Alles
 
 myinst.currentPlatforms.assignedSubscriptions = Zugeordnete aktive Lizenzen
-myinst.currentPlatforms.tooltip.thumbtack.content = Es wird eine eigene Zugangskonfiguration für Paket [{0}] verwendet
+myinst.currentPlatforms.tooltip.thumbtack.content = Es wird eine eigene Zugangskonfiguration verwendet
 
 myinst.dash.forum.label = Neueste Diskussionen
 myinst.dash.forum.noActivity = Forenaktivitäten nicht verfügbar. Bitte versuchen Sie es später noch einmal.

--- a/app/grails-app/views/myInstitution/currentPlatforms.gsp
+++ b/app/grails-app/views/myInstitution/currentPlatforms.gsp
@@ -72,21 +72,18 @@
             <td>
                 <g:each in="${subscriptionMap.get('platform_' + platformInstance.id)}" var="sub">
                     <g:link controller="subscription" action="show" id="${sub.id}">${sub}<br/></g:link>
+
                     <g:if test="${sub.packages}">
-                        <g:each in="${sub.packages}" var="sp">
-                            <g:if test="${!platformInstance.usesPlatformAccessPoints(contextOrg, sp)}">
-                                <g:each in="${sp.getAccessPointListForOrgAndPlatform(contextOrg, platformInstance)?.collect()}" var="orgap">
-                                <div class="la-flexbox">
-                                    <span data-position="top right"
-                                    class="la-popup-tooltip la-delay"
-                                    data-content="${message(code: 'myinst.currentPlatforms.tooltip.thumbtack.content', args:[sp.pkg.name])}">
+                        <g:each in="${sub.deduplicatedAccessPointsForOrgAndPlatform(contextOrg, platformInstance)}" var="orgap">
+                            <div class="la-flexbox">
+                                <span data-position="top right"
+                                      class="la-popup-tooltip la-delay"
+                                      data-content="${message(code: 'myinst.currentPlatforms.tooltip.thumbtack.content')}">
                                     <i class="icon la-thumbtack slash scale la-list-icon"></i>
-                                    </span>
-                                    <g:link controller="accessPoint" action="edit_${orgap.oap.accessMethod}"
-                                            id="${orgap.oap.id}">${orgap.oap.name} (${orgap.oap.accessMethod.getI10n('value')})</g:link>
-                                </div>
-                                </g:each>
-                            </g:if>
+                                </span>
+                                <g:link controller="accessPoint" action="edit_${orgap.accessMethod}"
+                                        id="${orgap.id}">${orgap.name} (${orgap.accessMethod.getI10n('value')})</g:link>
+                            </div>
                         </g:each>
                     </g:if>
                 </g:each>


### PR DESCRIPTION
Only show a distinct list of access points in the active license column on the my myplatforms list (do not list duplicated access points, if we have more than one package per platform)