### PR TITLE
bug-erms-2365

### DIFF
--- a/app/CHANGELOG-TMP.md
+++ b/app/CHANGELOG-TMP.md
@@ -2,6 +2,8 @@
 
 **Ticket    Date    Branch      Author  Feature/Bug     Description/Keywords**
 
+2365    14.04.2020  rc1.3       Andreas Bug         Konsortialstellen erhalten keine Dublette mehr bei Auswahl eines einzelnen Teilnehmers
+
 --      09.04.2020  rc1.3       David   Bug         Doppelte Menüeinträge entfernt
 
 2353    09.04.2020  rc1.3       Moe     Bug         Titelauswahlumfrage Bug beim Auswählen von Titel

--- a/app/grails-app/controllers/com/k_int/kbplus/FinanceController.groovy
+++ b/app/grails-app/controllers/com/k_int/kbplus/FinanceController.groovy
@@ -815,7 +815,7 @@ class FinanceController extends AbstractDebugController {
                       break
                   default:
                       if (params.newLicenseeTarget) {
-                          subsToDo << genericOIDService.resolveOID(params.newLicenseeTarget)
+                          subsToDo = [genericOIDService.resolveOID(params.newLicenseeTarget)]
                       }
                       break
               }

--- a/app/grails-app/services/com/k_int/kbplus/FinanceService.groovy
+++ b/app/grails-app/services/com/k_int/kbplus/FinanceService.groovy
@@ -1265,6 +1265,7 @@ class FinanceService {
                     else {
                         dataToDisplay << 'own'
                         result.showView = 'own'
+                        editable = true
                     }
                 }
                 //case eleven for all subscriptions


### PR DESCRIPTION
as of ERMS-2365, no local dublets are created for consortia when picking one member