### PR TITLE
various bugfixes

### DIFF
--- a/app/CHANGELOG-TMP.md
+++ b/app/CHANGELOG-TMP.md
@@ -7,6 +7,12 @@
 
 **Ticket    Date    Branch  Version(current) Author  Feature/Bug     Description/Keywords**
 
+--      15.09.2020  rc1.5   1.5.8       Andreas Bug         temporäre Brücke für unvollständig implementierten GOKb-Titeltyp OtherInstance eingebaut
+
+2860    15.09.2020  rc1.5   1.5.8       Andreas Bug         Nicht vererbte Merkmale werden bei Verträgen ohne Absturz dargestellt
+
+2808    15.09.2020  rc1.5   1.5.8       Andreas Bug         Konfigurierbarkeit der Merkmalsgruppen repariert
+
 2866    15.09.2020  rc1.5   1.5.8       David   Bug         Inkonsistente Merkmalsdefinitionen
 
 2851    11.09.2020  rc1.5   1.5.8       Moe     Bug         Fehler bei Filterung zentral verwalteter Lizenzen

--- a/app/grails-app/controllers/com/k_int/kbplus/LicenseController.groovy
+++ b/app/grails-app/controllers/com/k_int/kbplus/LicenseController.groovy
@@ -1153,7 +1153,7 @@ class LicenseController
 
     boolean showConsortiaFunctions(License license) {
 
-        return (license.getLicensingConsortium()?.id == contextService.getOrg().id)
+        return license.getLicensingConsortium()?.id == contextService.getOrg().id && license.getCalculatedType() == CalculatedType.TYPE_CONSORTIAL
     }
 
 }

--- a/app/grails-app/domain/com/k_int/kbplus/License.groovy
+++ b/app/grails-app/domain/com/k_int/kbplus/License.groovy
@@ -522,7 +522,14 @@ class License extends AbstractBaseWithCalculatedLastUpdated
 
             // cons_members
             if (this.instanceOf) {
-                PropertyDefinitionGroupBinding binding = PropertyDefinitionGroupBinding.findByPropDefGroupAndLic(it, this.instanceOf)
+                Long licId
+                if(this.getLicensingConsortium().id == contextOrg.id)
+                    licId = this.instanceOf.id
+                else licId = this.id
+                List<PropertyDefinitionGroupBinding> bindings = PropertyDefinitionGroupBinding.executeQuery('select b from PropertyDefinitionGroupBinding b where b.propDefGroup = :pdg and b.lic.id = :id and b.propDefGroup.tenant = :ctxOrg',[pdg:it, id: licId,ctxOrg:contextOrg])
+                PropertyDefinitionGroupBinding binding = null
+                if(bindings)
+                    binding = bindings.get(0)
 
                 // global groups
                 if (it.tenant == null) {

--- a/app/grails-app/domain/com/k_int/kbplus/Subscription.groovy
+++ b/app/grails-app/domain/com/k_int/kbplus/Subscription.groovy
@@ -667,7 +667,14 @@ class Subscription extends AbstractBaseWithCalculatedLastUpdated
 
             // cons_members
             if (this.instanceOf) {
-                PropertyDefinitionGroupBinding binding = PropertyDefinitionGroupBinding.findByPropDefGroupAndSub(it, this.instanceOf)
+                Long subId
+                if(this.getConsortia().id == contextOrg.id)
+                    subId = this.instanceOf.id
+                else subId = this.id
+                List<PropertyDefinitionGroupBinding> bindings = PropertyDefinitionGroupBinding.executeQuery('select b from PropertyDefinitionGroupBinding b where b.propDefGroup = :pdg and b.sub.id = :id and b.propDefGroup.tenant = :ctxOrg',[pdg:it, id: subId,ctxOrg:contextOrg])
+                PropertyDefinitionGroupBinding binding = null
+                if(bindings)
+                    binding = bindings.get(0)
 
                 // global groups
                 if (it.tenant == null) {

--- a/app/grails-app/domain/com/k_int/properties/PropertyDefinition.groovy
+++ b/app/grails-app/domain/com/k_int/properties/PropertyDefinition.groovy
@@ -1,13 +1,16 @@
 package com.k_int.properties
 
 import com.k_int.kbplus.GenericOIDService
+import com.k_int.kbplus.License
 import com.k_int.kbplus.Org
 import com.k_int.kbplus.RefdataValue
+import com.k_int.kbplus.Subscription
 import com.k_int.kbplus.abstract_domain.AbstractPropertyWithCalculatedLastUpdated
 import de.laser.ContextService
 import de.laser.I10nTranslation
 import de.laser.base.AbstractI10n
 import de.laser.helper.SwissKnife
+import de.laser.interfaces.CalculatedType
 import grails.util.Holders
 import groovy.util.logging.Log4j
 import org.apache.commons.logging.Log
@@ -305,7 +308,11 @@ class PropertyDefinition extends AbstractI10n implements Serializable, Comparabl
     static AbstractPropertyWithCalculatedLastUpdated createGenericProperty(String flag, def owner, PropertyDefinition type, Org contextOrg) {
         String classString = owner.getClass().toString()
         def ownerClassName = classString.substring(classString.lastIndexOf(".") + 1)
-        boolean isPublic
+        boolean isPublic = false
+        if(owner instanceof Subscription)
+            isPublic = owner.getCalculatedType() == CalculatedType.TYPE_PARTICIPATION && owner.getConsortia()?.id == contextOrg.id
+        else if(owner instanceof License)
+            isPublic = owner.getCalculatedType() == CalculatedType.TYPE_PARTICIPATION && owner.getLicensingConsortium()?.id == contextOrg.id
 
         //if(!owner.hasProperty("privateProperties")) {
             ownerClassName = "com.k_int.kbplus.${ownerClassName}Property"
@@ -320,7 +327,7 @@ class PropertyDefinition extends AbstractI10n implements Serializable, Comparabl
         }*/
 
         //def newProp = Class.forName(ownerClassName).newInstance(type: type, owner: owner)
-        def newProp = (new GroovyClassLoader()).loadClass(ownerClassName).newInstance(type: type, owner: owner, isPublic: false, tenant: contextOrg)
+        def newProp = (new GroovyClassLoader()).loadClass(ownerClassName).newInstance(type: type, owner: owner, isPublic: isPublic, tenant: contextOrg)
         newProp.setNote("")
 
         /*

--- a/app/grails-app/i18n/messages.properties
+++ b/app/grails-app/i18n/messages.properties
@@ -1512,7 +1512,8 @@ propertyDefinition.delete.failure.default = {0} could not be deleted.
 
 propertyDefinitionGroup.create_new.label = Create new property group
 propertyDefinitionGroup.config.label = Visibility configuration for property groups
-propertyDefinitionGroup.info.existingItems = Property group <strong>{0}</strong> contains <strong>{1}</strong> properties, but is hidden.
+propertyDefinitionGroup.info.existingItems = Property group <strong>{0}</strong> contains <strong>{1}</strong> more property/-ies, but is hidden.
+propertyDefinitionGroup.info.existingItems.withInheritance = Property group <strong>{0}</strong> contains <strong>{1}</strong> more property/-ies, but is hidden. Only inherited properties are being shown.
 propertyDefinitionGroup.table.header.description = Description
 propertyDefinitionGroup.table.header.properties = Properties
 propertyDefinitionGroup.table.header.presetShow = Show (preset)

--- a/app/grails-app/i18n/messages_de.properties
+++ b/app/grails-app/i18n/messages_de.properties
@@ -1508,7 +1508,8 @@ propertyDefinition.delete.failure.default = {0} konnte nicht gelöscht werden.
 
 propertyDefinitionGroup.create_new.label = Neue Merkmalsgruppe erstellen
 propertyDefinitionGroup.config.label = Sichtbarkeit von Merkmalen konfigurieren
-propertyDefinitionGroup.info.existingItems = Die Merkmalsgruppe <strong>{0}</strong> beinhaltet <strong>{1}</strong> Merkmale, ist aber ausgeblendet.
+propertyDefinitionGroup.info.existingItems = Die Merkmalsgruppe <strong>{0}</strong> beinhaltet <strong>{1}</strong> weitere(s) Merkmal(e), ist aber ausgeblendet.
+propertyDefinitionGroup.info.existingItems.withInheritance = Die Merkmalsgruppe <strong>{0}</strong> beinhaltet <strong>{1}</strong> weitere(s) Merkmal(e), ist aber ausgeblendet. Es werden nur die vererbten Merkmale angezeigt.
 propertyDefinitionGroup.table.header.description = Beschreibung
 propertyDefinitionGroup.table.header.properties = Merkmale
 propertyDefinitionGroup.table.header.presetShow = Anzeigen (Voreinstellung)

--- a/app/grails-app/services/de/laser/PropertyService.groovy
+++ b/app/grails-app/services/de/laser/PropertyService.groovy
@@ -250,9 +250,9 @@ class PropertyService {
             }
         }
 
-        log.debug('object             : ' + obj.class.simpleName + ' - ' + obj)
-        log.debug('orphanedIds        : ' + orphanedIds)
-        log.debug('orphaned Properties: ' + result)
+        //log.debug('object             : ' + obj.class.simpleName + ' - ' + obj)
+        //log.debug('orphanedIds        : ' + orphanedIds)
+        //log.debug('orphaned Properties: ' + result)
 
         result
     }

--- a/app/grails-app/views/license/_actions.gsp
+++ b/app/grails-app/views/license/_actions.gsp
@@ -41,7 +41,8 @@
                 </g:else>
             </g:if>
             <g:if test="${actionName == 'show'}">
-                <g:if test="${accessService.checkPermAffiliation('ORG_INST, ORG_CONSORTIUM','INST_EDITOR')}">
+                <%-- the second clause is to prevent the menu display for consortia at member subscriptions --%>
+                <g:if test="${accessService.checkPermAffiliation('ORG_INST, ORG_CONSORTIUM','INST_EDITOR') && !(org.id == license.getLicensingConsortium().id && license.instanceOf)}">
                     <div class="divider"></div>
                     <semui:actionsDropdownItem data-semui="modal" href="#propDefGroupBindings" message="menu.institutions.configure_prop_groups" />
                 </g:if>

--- a/app/grails-app/views/license/_properties.gsp
+++ b/app/grails-app/views/license/_properties.gsp
@@ -50,17 +50,18 @@
             String cat                             = entry[0]
             PropertyDefinitionGroup pdg            = entry[1]
             PropertyDefinitionGroupBinding binding = entry[2]
+            List numberOfConsortiaProperties       = institution.id != license.getLicensingConsortium().id ? pdg.getCurrentPropertiesOfTenant(license,license.getLicensingConsortium()) : []
 
             boolean isVisible = false
 
             if (cat == 'global') {
-                isVisible = pdg.isVisible
+                isVisible = pdg.isVisible || numberOfConsortiaProperties.size() > 0
             }
             else if (cat == 'local') {
                 isVisible = binding.isVisible
             }
             else if (cat == 'member') {
-                isVisible = binding.isVisible && binding.isVisibleForConsortiaMembers
+                isVisible = (binding.isVisible || numberOfConsortiaProperties.size() > 0) && binding.isVisibleForConsortiaMembers
             }
         %>
 
@@ -73,6 +74,14 @@
                     ownobj: license,
                     custom_props_div: "grouped_custom_props_div_${pdg.id}"
             ]}"/>
+            <g:if test="${!binding?.isVisible && !pdg.isVisible}">
+                <g:set var="numberOfProperties" value="${pdg.getCurrentPropertiesOfTenant(license,institution).size()-numberOfConsortiaProperties.size()}" />
+                <g:if test="${numberOfProperties > 0}">
+                    <%
+                        hiddenPropertiesMessages << "${message(code:'propertyDefinitionGroup.info.existingItems', args: [pdg.name, numberOfProperties])}"
+                    %>
+                </g:if>
+            </g:if>
         </g:if>
         <g:else>
             <g:set var="numberOfProperties" value="${pdg.getCurrentProperties(license)}" />

--- a/app/grails-app/views/subscription/_actions.gsp
+++ b/app/grails-app/views/subscription/_actions.gsp
@@ -202,7 +202,8 @@
 
             <g:if test="${actionName == 'show'}">
                 <%-- the editable setting needs to be the same as for the properties themselves -> override! --%>
-                <g:if test="${accessService.checkPermAffiliation('ORG_INST, ORG_CONSORTIUM','INST_EDITOR')}">
+                <%-- the second clause is to prevent the menu display for consortia at member subscriptions --%>
+                <g:if test="${accessService.checkPermAffiliation('ORG_INST, ORG_CONSORTIUM','INST_EDITOR') && !(org.id == subscriptionInstance.getConsortia().id && subscriptionInstance.instanceOf)}">
                     <div class="divider"></div>
                     <semui:actionsDropdownItem data-semui="modal" href="#propDefGroupBindings" message="menu.institutions.configure_prop_groups" />
                 </g:if>

--- a/app/grails-app/views/subscription/_properties.gsp
+++ b/app/grails-app/views/subscription/_properties.gsp
@@ -50,17 +50,18 @@
             String cat                             = entry[0]
             PropertyDefinitionGroup pdg            = entry[1]
             PropertyDefinitionGroupBinding binding = entry[2]
+            List numberOfConsortiaProperties       = contextService.getOrg().id != subscriptionInstance.getConsortia().id ? pdg.getCurrentPropertiesOfTenant(subscriptionInstance,subscriptionInstance.getConsortia()) : []
 
             boolean isVisible = false
 
             if (cat == 'global') {
-                isVisible = pdg.isVisible
+                isVisible = pdg.isVisible || numberOfConsortiaProperties.size() > 0
             }
             else if (cat == 'local') {
                 isVisible = binding.isVisible
             }
             else if (cat == 'member') {
-                isVisible = binding.isVisible && binding.isVisibleForConsortiaMembers
+                isVisible = (binding.isVisible || numberOfConsortiaProperties.size() > 0) && binding.isVisibleForConsortiaMembers
             }
         %>
 
@@ -73,10 +74,17 @@
                     ownobj: subscriptionInstance,
                     custom_props_div: "grouped_custom_props_div_${pdg.id}"
             ]}"/>
+            <g:if test="${!binding?.isVisible && !pdg.isVisible}">
+                <g:set var="numberOfProperties" value="${pdg.getCurrentPropertiesOfTenant(subscriptionInstance,contextService.getOrg()).size()-numberOfConsortiaProperties.size()}" />
+                <g:if test="${numberOfProperties > 0}">
+                    <%
+                        hiddenPropertiesMessages << "${message(code:'propertyDefinitionGroup.info.existingItems.withInheritance', args: [pdg.name, numberOfProperties])}"
+                    %>
+                </g:if>
+            </g:if>
         </g:if>
         <g:else>
-            <g:set var="numberOfProperties" value="${pdg.getCurrentProperties(subscriptionInstance)}" />
-
+            <g:set var="numberOfProperties" value="${pdg.getCurrentPropertiesOfTenant(subscriptionInstance,contextService.getOrg())}" />
             <g:if test="${numberOfProperties.size() > 0}">
                 <%
                     hiddenPropertiesMessages << "${message(code:'propertyDefinitionGroup.info.existingItems', args: [pdg.name, numberOfProperties.size()])}"

--- a/app/grails-app/views/templates/properties/_group.gsp
+++ b/app/grails-app/views/templates/properties/_group.gsp
@@ -31,7 +31,21 @@
         </thead>
     </g:if>
     <tbody>
-        <g:each in="${propDefGroup.getCurrentProperties(ownobj).sort{a, b -> a.type.getI10n('name').compareToIgnoreCase b.type.getI10n('name')}}" var="prop">
+        <g:if test="${ownobj instanceof License}">
+            <g:set var="consortium" value="${ownobj.getLicensingConsortium()}"/>
+            <g:set var="atSubscr" value="${ownobj.getCalculatedType() == de.laser.interfaces.CalculatedType.TYPE_PARTICIPATION}"/>
+        </g:if>
+        <g:elseif test="${ownobj instanceof Subscription}">
+            <g:set var="consortium" value="${ownobj.getConsortia()}"/>
+            <g:set var="atSubscr" value="${ownobj.getCalculatedType() == de.laser.interfaces.CalculatedType.TYPE_PARTICIPATION}"/>
+        </g:elseif>
+        <g:if test="${propDefGroup.isVisible || propDefGroupBinding?.isVisible}">
+            <g:set var="propDefGroupItems" value="${propDefGroup.getCurrentProperties(ownobj)}" />
+        </g:if>
+        <g:elseif test="${consortium != null}">
+            <g:set var="propDefGroupItems" value="${propDefGroup.getCurrentPropertiesOfTenant(ownobj,consortium)}" />
+        </g:elseif>
+        <g:each in="${propDefGroupItems.sort{a, b -> a.type.getI10n('name').compareToIgnoreCase b.type.getI10n('name')}}" var="prop">
             <g:set var="overwriteEditable" value="${(prop.tenant?.id == contextOrg.id && editable) || (!prop.tenant && editable)}"/>
             <g:if test="${(prop.tenant?.id == contextOrg.id || !prop.tenant) || prop.isPublic || (prop.hasProperty('instanceOf') && prop.instanceOf && AuditConfig.getConfig(prop.instanceOf))}">
                 <tr>
@@ -204,13 +218,6 @@
                             </g:else>
                         </g:if>
                         <g:else>
-                            <g:if test="${ownobj instanceof License}">
-                                <g:set var="consortium" value="${ownobj.getLicensingConsortium()}"/>
-                            </g:if>
-                            <g:elseif test="${ownobj instanceof Subscription}">
-                                <g:set var="consortium" value="${ownobj.getConsortia()}"/>
-                                <g:set var="atSubscr" value="${ownobj.getCalculatedType() == de.laser.interfaces.CalculatedType.TYPE_PARTICIPATION}"/>
-                            </g:elseif>
                             <g:if test="${prop.hasProperty('instanceOf') && prop.instanceOf && AuditConfig.getConfig(prop.instanceOf)}">
                                 <g:if test="${ownobj.isSlaved}">
                                     <span class="la-popup-tooltip la-delay" data-content="${message(code:'property.audit.target.inherit.auto')}" data-position="top right"><i class="large icon thumbtack blue"></i></span>

--- a/app/grails-app/views/templates/properties/_groupWrapper.gsp
+++ b/app/grails-app/views/templates/properties/_groupWrapper.gsp
@@ -24,6 +24,7 @@
              <%--!!!!Die Editable Prüfung dient dazu, dass für die Umfrag Lizenz-Merkmal nicht editierbar sind !!!!--%>
             <g:render template="/templates/properties/group" model="${[
                     propDefGroup: propDefGroup,
+                    propDefGroupBinding: propDefGroupBinding,
                     prop_desc: prop_desc,
                     ownobj: ownobj,
                     editable: (!(controllerName in ['survey', 'myInstitution'] ) && accessService.checkPermAffiliation('ORG_INST, ORG_CONSORTIUM','INST_EDITOR')),

--- a/app/grails-app/views/templates/properties/_members.gsp
+++ b/app/grails-app/views/templates/properties/_members.gsp
@@ -70,7 +70,9 @@
                 </td>
                 <td class="x">
                     <span class="la-popup-tooltip la-delay" data-content="${message(code:'property.notInherited.fromConsortia2')}" data-position="top right"><i class="large icon cart arrow down blue"></i></span>
-                    (<span data-tooltip="${message(code:'property.notInherited.info.propertyCount')}"><i class="ui icon sticky note blue"></i></span> ${com.k_int.kbplus.SubscriptionProperty.executeQuery('select sp from SubscriptionProperty sp where sp.owner in (:subscriptionSet) and sp.tenant = :context and sp.instanceOf = null and sp.type = :type', [subscriptionSet: memberSubs, context: contextOrg, type: propType]).size() ?: 0} / <span data-tooltip="${message(code:'property.notInherited.info.membersCount')}"><i class="ui icon clipboard blue"></i></span> ${memberSubs.size() ?: 0})
+                    <g:if test="${memberSubs}">
+                        (<span data-tooltip="${message(code:'property.notInherited.info.propertyCount')}"><i class="ui icon sticky note blue"></i></span> ${com.k_int.kbplus.SubscriptionProperty.executeQuery('select sp from SubscriptionProperty sp where sp.owner in (:subscriptionSet) and sp.tenant = :context and sp.instanceOf = null and sp.type = :type', [subscriptionSet: memberSubs, context: contextOrg, type: propType]).size() ?: 0} / <span data-tooltip="${message(code:'property.notInherited.info.membersCount')}"><i class="ui icon clipboard blue"></i></span> ${memberSubs.size() ?: 0})
+                    </g:if>
                 </td>
             </tr>
         </g:each>


### PR DESCRIPTION
includes commits for:
- ERMS-2808: configurability of property definition groups corrected
- ERMS-2860: crash fixed when displaying non-audited license properties
- no ticket temporary fix for global data sync for unimplemented title instance types